### PR TITLE
Declare odometry subscriber topic and goal_reached_tol. (#1770)

### DIFF
--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -23,6 +23,7 @@
 #include "nav2_util/robot_utils.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "tf2_ros/buffer.h"
+#include "nav2_util/node_utils.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -59,6 +60,8 @@ public:
   void initialize()
   {
     node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+    nav2_util::declare_parameter_if_not_declared(node_, "goal_reached_tol", 
+      rclcpp::ParameterValue(0.25));    
     node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
     tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
 

--- a/nav2_controller/src/progress_checker.cpp
+++ b/nav2_controller/src/progress_checker.cpp
@@ -18,6 +18,7 @@
 #include "nav_2d_utils/conversions.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose2_d.hpp"
+#include "nav2_util/node_utils.hpp"
 
 namespace nav2_controller
 {
@@ -26,6 +27,10 @@ static double pose_distance(const geometry_msgs::msg::Pose2D &, const geometry_m
 ProgressChecker::ProgressChecker(const rclcpp::Node::SharedPtr & node)
 : nh_(node)
 {
+  nav2_util::declare_parameter_if_not_declared(
+    nh_, "required_movement_radius", rclcpp::ParameterValue(0.5));
+  nav2_util::declare_parameter_if_not_declared(
+    nh_, "movement_time_allowance", rclcpp::ParameterValue(10.0));
   // Scale is set to 0 by default, so if it was not set otherwise, set to 0
   nh_->get_parameter_or("required_movement_radius", radius_, 0.5);
   double time_allowance_param;

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -66,6 +66,8 @@ public:
     std::string default_topic = "odom")
   {
     std::string odom_topic;
+    nav2_util::declare_parameter_if_not_declared(nh, "odom_topic", 
+      rclcpp::ParameterValue(default_topic));    
     nh->get_parameter_or("odom_topic", odom_topic, default_topic);
     odom_sub_ =
       nh->create_subscription<nav_msgs::msg::Odometry>(odom_topic,


### PR DESCRIPTION
* Declare progress checker parameters (#1526)

* Declare progress checker parameters

* Use declare_if_not_declared function

This should allow the node to be brought down and back up using
the lifecycle manager.

* Declared parameters before get.

* Fixed column width.

* Removed changes not related to parameter declare.

Co-authored-by: Carl Delsey <carl.r.delsey@intel.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
